### PR TITLE
fix: start multi-server enumeration from one

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 pgAdmin4 container image with password-less usage configuration.
 
-Sample `docker-compose.yml` usage:
+Sample `docker-compose.yml`:
 
 ```yaml
   pgadmin4:
@@ -12,8 +12,8 @@ Sample `docker-compose.yml` usage:
     environment:
       POSTGRES_USER: my_user
       POSTGRES_PASSWORD: my_pass
-      # POSTGRES_HOST: "postgres"
-      # POSTGRES_PORT: "5432"
+      POSTGRES_HOST: "postgres"
+      POSTGRES_PORT: "5432"
       # POSTGRES_DB: "*"
 ```
 
@@ -29,15 +29,15 @@ A quick example could be found in [`docker-compose.yml`](https://github.com/dogu
 
 ### Multi Server Config
 
-You can add more hosts by adding enumerated environment variables, where X is the number of the host (starting from **2**):
+You can configure multiple hosts by adding enumerated environment variables, where X is the index of the host (starting from `1`):
 
 - `POSTGRES_USER_X`: Postgres DB user name. (**Required**)
 - `POSTGRES_PASSWORD_X`: Postgres DB user password. (**Required**)
 - `POSTGRES_HOST_X`: PostgreSQL DB Host. (**Required**)
 - `POSTGRES_PORT_X`: PostgreSQL DB Port. (Default: _5432_)
-- `POSTGRES_DB_X`: PostgreSQL DB name. (Default: _\*_, Asterisk means any db.)
+- `POSTGRES_DB_X`: PostgreSQL DB name. (Default: _\*_, meaning any db.)
 
-An multi database example usage could be found in [`docker-compose-multi.yml`](https://github.com/dogukancagatay/docker-pwless-pgadmin4/blob/master/docker-compose-multi.yml).
+A multi database example usage could be found in [`docker-compose-multi.yml`](https://github.com/dogukancagatay/docker-pwless-pgadmin4/blob/master/docker-compose-multi.yml).
 
 ## Links
 

--- a/docker-compose-multi.yml
+++ b/docker-compose-multi.yml
@@ -58,11 +58,11 @@ services:
     ports:
       - 25432:80
     environment:
-      POSTGRES_USER: my_user
-      POSTGRES_PASSWORD: my_pass
-      # POSTGRES_HOST: "postgres"
-      # POSTGRES_PORT: "5432"
-      # POSTGRES_DB: "*"
+      POSTGRES_USER_1: my_user
+      POSTGRES_PASSWORD_1: my_pass
+      # POSTGRES_HOST_1: "postgres"
+      # POSTGRES_PORT_1: "5432"
+      # POSTGRES_DB_1: "*"
 
       POSTGRES_USER_2: my_user2
       POSTGRES_PASSWORD_2: my_pass2

--- a/primary_entrypoint.sh
+++ b/primary_entrypoint.sh
@@ -4,13 +4,14 @@ set -e
 
 ## Create /var/lib/pgadmin/pgpass
 # 1st database
-echo "$POSTGRES_HOST:$POSTGRES_PORT:postgres:$POSTGRES_USER:$POSTGRES_PASSWORD" | tee -a "/var/lib/pgadmin/pgpass" >/dev/null
-echo "$POSTGRES_HOST:$POSTGRES_PORT:$POSTGRES_DB:$POSTGRES_USER:$POSTGRES_PASSWORD" | tee -a "/var/lib/pgadmin/pgpass" >/dev/null
-POSTGRES_HOST_1=$POSTGRES_HOST
-POSTGRES_PORT_1=$POSTGRES_PORT
-POSTGRES_DB_1=$POSTGRES_DB
-POSTGRES_USER_1=$POSTGRES_USER
-POSTGRES_PASSWORD_1=$POSTGRES_PASSWORD
+POSTGRES_HOST_1=${POSTGRES_HOST_1:-$POSTGRES_HOST}
+POSTGRES_PORT_1=${POSTGRES_PORT_1:-$POSTGRES_PORT}
+POSTGRES_DB_1=${POSTGRES_DB_1:-$POSTGRES_DB}
+POSTGRES_USER_1=${POSTGRES_USER_1:-$POSTGRES_USER}
+POSTGRES_PASSWORD_1=${POSTGRES_PASSWORD_1:-$POSTGRES_PASSWORD}
+
+echo "$POSTGRES_HOST_1:$POSTGRES_PORT_1:postgres:$POSTGRES_USER_1:$POSTGRES_PASSWORD_1" | tee -a "/var/lib/pgadmin/pgpass" >/dev/null
+echo "$POSTGRES_HOST_1:$POSTGRES_PORT_1:$POSTGRES_DB_1:$POSTGRES_USER_1:$POSTGRES_PASSWORD_1" | tee -a "/var/lib/pgadmin/pgpass" >/dev/null
 
 ## Create servers.json
 tee /pgadmin4/servers.json >/dev/null <<EOF
@@ -32,32 +33,32 @@ EOF
 # loop through environment variables and create password files
 COUNT=2
 while [ ! -z "$(eval echo \"\$POSTGRES_HOST_$COUNT\")" ]; do
-    POSTGRES_HOST="$(eval echo \"\$POSTGRES_HOST_$COUNT\")"
-    POSTGRES_PORT="$(eval echo \"\$POSTGRES_PORT_$COUNT\")"
+    _POSTGRES_HOST="$(eval echo \"\$POSTGRES_HOST_$COUNT\")"
+    _POSTGRES_PORT="$(eval echo \"\$POSTGRES_PORT_$COUNT\")"
 
     # Set default for the postgres port
-    if [ -z "$POSTGRES_PORT" ]; then
-        POSTGRES_PORT="5432"
+    if [ -z "$_POSTGRES_PORT" ]; then
+        _POSTGRES_PORT="5432"
     fi
 
     # if POSTGRES_DB, default is "*"
-    POSTGRES_DB="$(eval echo \"\$POSTGRES_DB_$COUNT\")"
-    if [ -z "$POSTGRES_DB" ]; then
-        POSTGRES_DB="*"
+    _POSTGRES_DB="$(eval echo \"\$POSTGRES_DB_$COUNT\")"
+    if [ -z "$_POSTGRES_DB" ]; then
+        _POSTGRES_DB="*"
     fi
-    POSTGRES_USER="$(eval echo \"\$POSTGRES_USER_$COUNT\")"
-    POSTGRES_PASSWORD="$(eval echo \"\$POSTGRES_PASSWORD_$COUNT\")"
-    echo "$POSTGRES_HOST:$POSTGRES_PORT:postgres:$POSTGRES_USER:$POSTGRES_PASSWORD" | tee -a "/var/lib/pgadmin/pgpass_$COUNT" >/dev/null
-    echo "$POSTGRES_HOST:$POSTGRES_PORT:$POSTGRES_DB:$POSTGRES_USER:$POSTGRES_PASSWORD" | tee -a "/var/lib/pgadmin/pgpass_$COUNT" >/dev/null
+    _POSTGRES_USER="$(eval echo \"\$POSTGRES_USER_$COUNT\")"
+    _POSTGRES_PASSWORD="$(eval echo \"\$POSTGRES_PASSWORD_$COUNT\")"
+    echo "$_POSTGRES_HOST:$_POSTGRES_PORT:postgres:$_POSTGRES_USER:$_POSTGRES_PASSWORD" | tee -a "/var/lib/pgadmin/pgpass_$COUNT" >/dev/null
+    echo "$_POSTGRES_HOST:$_POSTGRES_PORT:$_POSTGRES_DB:$_POSTGRES_USER:$_POSTGRES_PASSWORD" | tee -a "/var/lib/pgadmin/pgpass_$COUNT" >/dev/null
 
     tee -a /pgadmin4/servers.json >/dev/null <<EOF
         ,"$COUNT": {
-            "Name": "$POSTGRES_HOST",
+            "Name": "$_POSTGRES_HOST",
             "Group": "Servers",
-            "Host": "$POSTGRES_HOST",
-            "Port": $POSTGRES_PORT,
+            "Host": "$_POSTGRES_HOST",
+            "Port": $_POSTGRES_PORT,
             "MaintenanceDB": "postgres",
-            "Username": "$POSTGRES_USER",
+            "Username": "$_POSTGRES_USER",
             "SSLMode": "prefer",
             "PassFile": "/var/lib/pgadmin/pgpass_$COUNT"
         }
@@ -72,8 +73,8 @@ tee -a /pgadmin4/servers.json >/dev/null <<EOF
 }
 EOF
 
-chmod 600 `ls /var/lib/pgadmin/pgpass*`
-chown pgadmin:root `ls /var/lib/pgadmin/pgpass*`
+chmod 600 /var/lib/pgadmin/pgpass*
+chown pgadmin:root /var/lib/pgadmin/pgpass*
 chown pgadmin:root /pgadmin4/servers.json
 
 exec /entrypoint.sh "$@"


### PR DESCRIPTION
The multi-server configuration enumeration was starting from `2`, this
PR make it start from `1` without breaking the backwards compatibility.

The first server's environment variables can be defined with `_1` suffix
or not. e.g `POSTGRES_USER` or `POSTGRES_USER_1`.

Addresses #30.
