### PR TITLE
hore: update GitHub Actions versions

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -12,7 +12,6 @@ on:
         default: false
         type: boolean
 
-
 jobs:
   build-container:
     runs-on: ubuntu-latest
@@ -21,19 +20,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push container image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
           push: ${{ inputs.should_push_image }}
@@ -42,7 +41,7 @@ jobs:
 
       - name: Update Dockerhub description
         if: ${{ inputs.should_update_repo_description }}
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Bump third-party workflow actions for Docker image builds:
- docker/setup-qemu-action to v4
- docker/setup-buildx-action to v4
- docker/login-action to v4
- docker/build-push-action to v7
- peter-evans/dockerhub-description to v5
